### PR TITLE
Aggiunta creazione database di test e upload Google Drive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 mysqlbackup.config
+mysqlbackup.lock

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Table of Contents
 - bash
 - mysql / mysqldump
 - curl (required for Google Drive upload)
-- gzip (optional, used for compressed intermediate dumps)
+- gzip (required for `--create-database-test`; otherwise used for compressed intermediate dumps)
 
 # Install
 

--- a/README.md
+++ b/README.md
@@ -1,30 +1,30 @@
 
 # mysqlbackup.sh
-Bash script to daily backup all your database in gzip with weekly history. 
+Bash script to daily backup all your MySQL databases in gzip with weekly history.
 
 [![Software License][ico-license]](LICENSE.md)
 
 Table of Contents
 =================
 
-  * [mysqlbackup.sh](#mysqlbackup.sh)
-  * [Table of Contents](#table-of-contents)
   * [Prerequisites](#prerequisites)
   * [Install](#install)
   * [Usage](#usage)
-  * [Example](#example)
+  * [Create test database](#create-test-database)
+  * [Google Drive upload](#google-drive-upload)
+  * [Configuration reference](#configuration-reference)
   * [Contributing](#contributing)
   * [Credits](#credits)
-  * [About Padosoft](#about-padosoft)
   * [License](#license)
 
 # Prerequisites
 
-bash
+- bash
+- mysql / mysqldump
+- curl (required for Google Drive upload)
+- gzip (optional, used for compressed intermediate dumps)
 
 # Install
-
-This package can be installed easy.
 
 ``` bash
 cd /root/myscript
@@ -33,44 +33,176 @@ cd mysqlbackup.sh
 chmod +x mysqlbackup.sh
 ```
 
-
-If you want to set your value and override default var values create a mysqlbackup.config file by coping the given template mysqlbackup.config.template, 
-open in your favorite editor and make changes:
+Create a config file from the template and set your variables:
 
 ``` bash
-cp /root/myscript/mysqlbackup.sh/mysqlbackup.config.template /root/myscript/mysqlbackup.sh/mysqlbackup.config 
-
-nano /root/myscript/mysqlbackup.sh/mysqlbackup.config
+cp mysqlbackup.config.template mysqlbackup.config
+nano mysqlbackup.config
 ```
 
+`mysqlbackup.config` is excluded from git (contains credentials).
 
-If you want to run programmatically, add it to cronjobs manually or execute install script:
+To run automatically every day at midnight, add a cronjob manually or run the install script:
 
 ``` bash
-cd /root/myscript/mysqlbackup.sh
 chmod +x install.sh
 bash install.sh
 ```
 
-
 # Usage
+
+**Backup all databases (standard daily backup):**
+
 ``` bash
 bash mysqlbackup.sh
 ```
 
-## Example
+**Backup specific databases only:**
+
 ``` bash
-bash mysqlbackup.sh
+bash mysqlbackup.sh --databases mydb1,mydb2
 ```
-For help:
+
+**Hourly backup (uses hourlyHH suffix instead of day name):**
+
 ``` bash
-bash mysqlbackup.sh
+bash mysqlbackup.sh --hourly
 ```
+
+**Exclude tables from the backup:**
+
+``` bash
+# Exclude predefined table groups (configured in mysqlbackup.config)
+bash mysqlbackup.sh --escludi_tabelle_queue
+bash mysqlbackup.sh --escludi_tabelle_servizio
+bash mysqlbackup.sh --escludi_tabelle_storico
+bash mysqlbackup.sh --escludi_tabelle_statistiche
+bash mysqlbackup.sh --escludi_tutte
+
+# Exclude specific tables
+bash mysqlbackup.sh --escludi_tabelle_custom table1,table2
+```
+
+Excluded tables still have their schema exported (structure only, no data).
+
+## Output
+
+Backups are saved in `<DEFPATH>/data/<database>/` with weekly rotation:
+
+```
+/home/backup/data/mydb/mydb-Mon-dump.sql.gz
+/home/backup/data/mydb/mydb-Tue-dump.sql.gz
+...
+```
+
+Each day's file overwrites the same day from the previous week.
+
+# Create test database
+
+Create a test database from production, useful for providing developers with a sanitized copy of production data.
+
+**Flow:** dump production DB -> import into test DB -> run SQL transformation scripts -> export test DB
+
+``` bash
+bash mysqlbackup.sh --create-database-test --databases mydb_production
+```
+
+**Requirements:**
+
+1. Set `TEST_DATABASE_NAME` in `mysqlbackup.config` (must be different from the production database name)
+2. The test database must already exist on the MySQL server (`CREATE DATABASE mydb_test`)
+3. Use `--databases` with exactly one database name
+
+**SQL transformation scripts:**
+
+Place `.sql` files in the `sql_script_for_test_db/` directory (or configure `SQL_SCRIPTS_DIR` in config). Scripts are executed in alphabetical/numeric order after the import. Use these to anonymize data, remove sensitive information, etc.
+
+Example naming convention:
+```
+sql_script_for_test_db/
+  001_anonymize_users.sql
+  002_clear_logs.sql
+  003_reset_passwords.sql
+```
+
+**Table exclusions** (`--escludi_tabelle_*`) are compatible with `--create-database-test` to exclude large or unnecessary tables from the test database.
+
+When `--create-database-test` is used, the standard backup is skipped. Only the test database creation flow runs.
+
+# Google Drive upload
+
+Automatically upload the test database export to Google Drive after creation.
+
+## Setup
+
+1. Go to [Google Cloud Console](https://console.cloud.google.com)
+2. Create a project (or use an existing one)
+3. Enable the **Google Drive API**
+4. Go to **APIs & Services** -> **Credentials** -> **Create Credentials** -> **OAuth client ID**
+5. Application type: **Desktop app** (or Web, with `http://localhost` as redirect URI)
+6. Add your Google account as a test user in **OAuth consent screen** -> **Audience**
+7. Run the authorization flow to get a refresh token:
+
+``` bash
+# Open this URL in your browser (replace CLIENT_ID):
+https://accounts.google.com/o/oauth2/auth?client_id=YOUR_CLIENT_ID&redirect_uri=http://localhost&response_type=code&scope=https://www.googleapis.com/auth/drive&access_type=offline&prompt=consent
+
+# After authorization, the browser redirects to http://localhost/?code=XXXX
+# Exchange the code for a refresh token:
+curl -s -X POST "https://oauth2.googleapis.com/token" \
+  -d "code=AUTHORIZATION_CODE" \
+  -d "client_id=YOUR_CLIENT_ID" \
+  -d "client_secret=YOUR_CLIENT_SECRET" \
+  -d "redirect_uri=http://localhost" \
+  -d "grant_type=authorization_code"
+```
+
+8. Copy the `refresh_token` from the response and configure `mysqlbackup.config`:
+
+``` bash
+GDRIVE_CLIENT_ID="your-client-id"
+GDRIVE_CLIENT_SECRET="your-client-secret"
+GDRIVE_REFRESH_TOKEN="your-refresh-token"
+GDRIVE_FOLDER_ID="your-folder-id"        # from the Google Drive folder URL
+GDRIVE_MAX_SIZE_MB=500                     # skip upload if file exceeds 500 MB (0 = no limit)
+GDRIVE_KEEP_FILES=2                        # keep only the last 2 files per database on Drive (0 = no pruning)
+```
+
+The uploaded file is named `<database>_YYYY-MM-DD.sql.gz`.
+
+## Pruning
+
+When `GDRIVE_KEEP_FILES` is set to a value greater than 0, old files are automatically deleted from Google Drive after each upload. Files are matched by database name prefix and sorted by creation date. Only the most recent N files are kept.
+
+# Configuration reference
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DBUSER` | `admin` | MySQL username |
+| `DBPASS` | Plesk shadow file or empty | MySQL password |
+| `DBPORT` | `3306` | MySQL port |
+| `DBHOST` | (empty = localhost) | MySQL host |
+| `DBOPTION` | `-f --routines` | mysqldump options |
+| `DEFPATH` | `/home/backup/` | Backup destination directory |
+| `MYSQLBIN` | `/usr/bin/mysql` | Path to mysql binary |
+| `MYSQLDUMPBIN` | `/usr/bin/mysqldump` | Path to mysqldump binary |
+| `EXCLUDE_TABLES_QUEUE` | `()` | Tables to exclude with `--escludi_tabelle_queue` |
+| `EXCLUDE_TABLES_LOG_CACHE_SERVIZIO` | `()` | Tables to exclude with `--escludi_tabelle_servizio` |
+| `EXCLUDE_TABLES_STORICO` | `()` | Tables to exclude with `--escludi_tabelle_storico` |
+| `EXCLUDE_TABLES_STATISTICHE` | `()` | Tables to exclude with `--escludi_tabelle_statistiche` |
+| `EXCLUDE_TABLES_HOURLY` | `()` | Tables to exclude with `--hourly` |
+| `TEST_DATABASE_NAME` | (empty) | Name of the test database |
+| `SQL_SCRIPTS_DIR` | `sql_script_for_test_db/` | Directory containing SQL transformation scripts |
+| `GDRIVE_CLIENT_ID` | (empty) | OAuth2 Client ID |
+| `GDRIVE_CLIENT_SECRET` | (empty) | OAuth2 Client Secret |
+| `GDRIVE_REFRESH_TOKEN` | (empty) | OAuth2 Refresh Token |
+| `GDRIVE_FOLDER_ID` | (empty) | Google Drive destination folder ID |
+| `GDRIVE_MAX_SIZE_MB` | `0` | Max file size in MB for upload (0 = no limit) |
+| `GDRIVE_KEEP_FILES` | `0` | Files to keep per db on Drive (0 = no pruning) |
 
 # Contributing
 
 Please see [CONTRIBUTING](CONTRIBUTING.md) and [CONDUCT](CONDUCT.md) for details.
-
 
 # Credits
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Table of Contents
   * [Usage](#usage)
   * [Create test database](#create-test-database)
   * [Google Drive upload](#google-drive-upload)
+  * [Lock file](#lock-file)
   * [Configuration reference](#configuration-reference)
   * [Contributing](#contributing)
   * [Credits](#credits)
@@ -174,6 +175,14 @@ The uploaded file is named `<database>_YYYY-MM-DD.sql.gz`.
 
 When `GDRIVE_KEEP_FILES` is set to a value greater than 0, old files are automatically deleted from Google Drive after each upload. Files are matched by database name prefix and sorted by creation date. Only the most recent N files are kept.
 
+# Lock file
+
+The script creates a `mysqlbackup.lock` file to prevent concurrent executions. If the script is already running, a second instance will exit with an error.
+
+If the lock file is older than `LOCK_TIMEOUT_MINUTES` (default: 120 minutes / 2 hours), it is considered stale and automatically removed with a warning. This handles cases where a previous run crashed without cleaning up.
+
+The lock file is automatically removed on exit (including errors) via a `trap`.
+
 # Configuration reference
 
 | Variable | Default | Description |
@@ -199,6 +208,7 @@ When `GDRIVE_KEEP_FILES` is set to a value greater than 0, old files are automat
 | `GDRIVE_FOLDER_ID` | (empty) | Google Drive destination folder ID |
 | `GDRIVE_MAX_SIZE_MB` | `0` | Max file size in MB for upload (0 = no limit) |
 | `GDRIVE_KEEP_FILES` | `0` | Files to keep per db on Drive (0 = no pruning) |
+| `LOCK_TIMEOUT_MINUTES` | `120` | Lock file timeout in minutes before forced removal |
 
 # Contributing
 

--- a/mysqlbackup.config.template
+++ b/mysqlbackup.config.template
@@ -24,7 +24,9 @@ EXCLUDE_TABLES_HOURLY=()
 TEST_DATABASE_NAME=""
 SQL_SCRIPTS_DIR=""  # Default: sql_script_for_test_db/ nella directory dello script
 
-# Google Drive upload settings
-GDRIVE_SERVICE_ACCOUNT_JSON=""  # Path al file JSON del service account
+# Google Drive upload settings (OAuth2)
+GDRIVE_CLIENT_ID=""             # OAuth2 Client ID
+GDRIVE_CLIENT_SECRET=""         # OAuth2 Client Secret
+GDRIVE_REFRESH_TOKEN=""         # OAuth2 Refresh Token (ottenuto una tantum via browser)
 GDRIVE_FOLDER_ID=""             # ID della cartella di destinazione su Google Drive
 GDRIVE_MAX_SIZE_MB=0            # Dimensione massima in MB (0 = nessun limite)

--- a/mysqlbackup.config.template
+++ b/mysqlbackup.config.template
@@ -23,3 +23,8 @@ EXCLUDE_TABLES_HOURLY=()
 # Test database settings
 TEST_DATABASE_NAME=""
 SQL_SCRIPTS_DIR=""  # Default: sql_script_for_test_db/ nella directory dello script
+
+# Google Drive upload settings
+GDRIVE_SERVICE_ACCOUNT_JSON=""  # Path al file JSON del service account
+GDRIVE_FOLDER_ID=""             # ID della cartella di destinazione su Google Drive
+GDRIVE_MAX_SIZE_MB=0            # Dimensione massima in MB (0 = nessun limite)

--- a/mysqlbackup.config.template
+++ b/mysqlbackup.config.template
@@ -19,3 +19,7 @@ EXCLUDE_TABLES_LOG_CACHE_SERVIZIO=()
 EXCLUDE_TABLES_STORICO=()
 EXCLUDE_TABLES_STATISTICHE=()
 EXCLUDE_TABLES_HOURLY=()
+
+# Test database settings
+TEST_DATABASE_NAME=""
+SQL_SCRIPTS_DIR=""  # Default: sql_script_for_test_db/ nella directory dello script

--- a/mysqlbackup.config.template
+++ b/mysqlbackup.config.template
@@ -31,3 +31,4 @@ GDRIVE_REFRESH_TOKEN=""         # OAuth2 Refresh Token (ottenuto una tantum via 
 GDRIVE_FOLDER_ID=""             # ID della cartella di destinazione su Google Drive
 GDRIVE_MAX_SIZE_MB=0            # Dimensione massima in MB (0 = nessun limite)
 GDRIVE_KEEP_FILES=0             # Numero di file da mantenere su Drive per ogni db (0 = nessun pruning)
+LOCK_TIMEOUT_MINUTES=120        # Timeout del lock file in minuti (default 2 ore)

--- a/mysqlbackup.config.template
+++ b/mysqlbackup.config.template
@@ -30,3 +30,4 @@ GDRIVE_CLIENT_SECRET=""         # OAuth2 Client Secret
 GDRIVE_REFRESH_TOKEN=""         # OAuth2 Refresh Token (ottenuto una tantum via browser)
 GDRIVE_FOLDER_ID=""             # ID della cartella di destinazione su Google Drive
 GDRIVE_MAX_SIZE_MB=0            # Dimensione massima in MB (0 = nessun limite)
+GDRIVE_KEEP_FILES=0             # Numero di file da mantenere su Drive per ogni db (0 = nessun pruning)

--- a/mysqlbackup.sh
+++ b/mysqlbackup.sh
@@ -17,6 +17,9 @@ INCLUDE_DATABASES=()
 CREATE_DATABASE_TEST=false
 TEST_DATABASE_NAME=""
 SQL_SCRIPTS_DIR=""
+GDRIVE_SERVICE_ACCOUNT_JSON=""
+GDRIVE_FOLDER_ID=""
+GDRIVE_MAX_SIZE_MB=0
 
 EXCLUDE_TABLES_QUEUE=()
 EXCLUDE_TABLES_LOG_CACHE_SERVIZIO=()
@@ -133,6 +136,79 @@ if [ "$DBHOST" != "" ]; then
 fi
 
 MYSQLCOMMAND+="$MYSQLCONFIG"
+
+#
+# Funzioni per upload su Google Drive via Service Account
+#
+
+# Ottiene un access token OAuth2 dal Service Account JSON usando JWT firmato con openssl
+get_gdrive_token() {
+    # Estrae i campi dal JSON del service account
+    local client_email=$(grep '"client_email"' "$GDRIVE_SERVICE_ACCOUNT_JSON" | sed 's/.*: *"\(.*\)".*/\1/')
+    local token_uri=$(grep '"token_uri"' "$GDRIVE_SERVICE_ACCOUNT_JSON" | sed 's/.*: *"\(.*\)".*/\1/')
+
+    # Estrae la private key (campo multilinea con \n)
+    local private_key=$(sed -n '/private_key/,/-----END/p' "$GDRIVE_SERVICE_ACCOUNT_JSON" | sed 's/.*: *"//;s/",*$//' | sed 's/\\n/\n/g')
+
+    # JWT header e claim
+    local now=$(date +%s)
+    local exp=$((now + 3600))
+    local header='{"alg":"RS256","typ":"JWT"}'
+    local claim="{\"iss\":\"$client_email\",\"scope\":\"https://www.googleapis.com/auth/drive.file\",\"aud\":\"$token_uri\",\"iat\":$now,\"exp\":$exp}"
+
+    # Base64url encoding
+    local b64_header=$(echo -n "$header" | openssl base64 -e | tr -d '=\n' | tr '+/' '-_')
+    local b64_claim=$(echo -n "$claim" | openssl base64 -e | tr -d '=\n' | tr '+/' '-_')
+
+    # Firma RSA-SHA256 con la private key del service account
+    local signature=$(echo -n "$b64_header.$b64_claim" | openssl dgst -sha256 -sign <(echo "$private_key") | openssl base64 -e | tr -d '=\n' | tr '+/' '-_')
+
+    local jwt="$b64_header.$b64_claim.$signature"
+
+    # Scambia il JWT per un access token
+    local response=$(curl -s -X POST "$token_uri" \
+        -H "Content-Type: application/x-www-form-urlencoded" \
+        -d "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=$jwt")
+
+    echo "$response" | grep -o '"access_token" *: *"[^"]*"' | sed 's/.*: *"\(.*\)"/\1/'
+}
+
+# Carica un file su Google Drive con controllo dimensione massima
+upload_to_gdrive() {
+    local file_path="$1"
+    local file_name=$(basename "$file_path")
+
+    # Controllo dimensione massima
+    if [ "$GDRIVE_MAX_SIZE_MB" -gt 0 ]; then
+        local file_size_mb=$(( $(stat -c%s "$file_path" 2>/dev/null || stat -f%z "$file_path") / 1048576 ))
+        if [ "$file_size_mb" -gt "$GDRIVE_MAX_SIZE_MB" ]; then
+            echo "Warning: file $file_name ($file_size_mb MB) supera il limite di $GDRIVE_MAX_SIZE_MB MB, upload skippato"
+            return 0
+        fi
+    fi
+
+    # Ottieni access token dal service account
+    local token=$(get_gdrive_token)
+    if [ -z "$token" ]; then
+        echo "Errore: impossibile ottenere access token per Google Drive"
+        return 1
+    fi
+
+    # Upload via API Google Drive (multipart upload)
+    echo "Uploading $file_name to Google Drive..."
+    local response=$(curl -s -X POST \
+        -H "Authorization: Bearer $token" \
+        -F "metadata={\"name\":\"$file_name\",\"parents\":[\"$GDRIVE_FOLDER_ID\"]};type=application/json;charset=UTF-8" \
+        -F "file=@$file_path;type=application/gzip" \
+        "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart")
+
+    if echo "$response" | grep -q '"id"'; then
+        echo "Upload completed: $file_name"
+    else
+        echo "Errore upload Google Drive: $response"
+        return 1
+    fi
+}
 
 echo "retrieve databases..."
 echo $MYSQLCOMMAND
@@ -256,6 +332,13 @@ if [ "$CREATE_DATABASE_TEST" = true ]; then
     else
         echo "Errore: export del database di test fallito o vuoto"
         rm -f "$BACKUP_FILE_TEST"
+    fi
+
+    # Step 6: Upload su Google Drive (se configurato)
+    if [ -n "$GDRIVE_SERVICE_ACCOUNT_JSON" ] && [ -n "$GDRIVE_FOLDER_ID" ]; then
+        if [ -s "$BACKUP_FILE_TEST" ]; then
+            upload_to_gdrive "$BACKUP_FILE_TEST"
+        fi
     fi
 
     # Cleanup: rimuove il file .sql temporaneo

--- a/mysqlbackup.sh
+++ b/mysqlbackup.sh
@@ -230,11 +230,11 @@ prune_gdrive_files() {
         "https://www.googleapis.com/drive/v3/files?q='$GDRIVE_FOLDER_ID'+in+parents+and+name+contains+'${file_prefix}'+and+trashed=false&orderBy=createdTime+desc&fields=files(id,name,createdTime)&pageSize=100")
 
     # Parsing dei risultati: estrae coppie id/name e salta i primi N (da mantenere)
-    local count=0
+    # Usa process substitution per evitare subshell (le variabili devono persistere tra iterazioni)
     local i=0
     local current_id=""
 
-    echo "$response" | grep -o '"id": *"[^"]*"\|"name": *"[^"]*"' | sed 's/.*: *"\(.*\)"/\1/' | while read -r value; do
+    while read -r value; do
         if [ -z "$current_id" ]; then
             # Primo valore della coppia: id
             current_id="$value"
@@ -248,7 +248,7 @@ prune_gdrive_files() {
             fi
             current_id=""
         fi
-    done
+    done < <(echo "$response" | grep -o '"id": *"[^"]*"\|"name": *"[^"]*"' | sed 's/.*: *"\(.*\)"/\1/')
 }
 
 echo "retrieve databases..."

--- a/mysqlbackup.sh
+++ b/mysqlbackup.sh
@@ -174,9 +174,10 @@ get_gdrive_token() {
 }
 
 # Carica un file su Google Drive con controllo dimensione massima
+# Parametri: $1 = path del file, $2 = nome del file su Drive (opzionale, default = basename)
 upload_to_gdrive() {
     local file_path="$1"
-    local file_name=$(basename "$file_path")
+    local file_name="${2:-$(basename "$file_path")}"
 
     # Controllo dimensione massima
     if [ "$GDRIVE_MAX_SIZE_MB" -gt 0 ]; then
@@ -335,9 +336,11 @@ if [ "$CREATE_DATABASE_TEST" = true ]; then
     fi
 
     # Step 6: Upload su Google Drive (se configurato)
+    # Il file su Drive si chiama nomedbprod_YYYY-MM-DD.sql.gz
     if [ -n "$GDRIVE_SERVICE_ACCOUNT_JSON" ] && [ -n "$GDRIVE_FOLDER_ID" ]; then
         if [ -s "$BACKUP_FILE_TEST" ]; then
-            upload_to_gdrive "$BACKUP_FILE_TEST"
+            GDRIVE_FILE_NAME="${database}_$(date +%Y-%m-%d).sql.gz"
+            upload_to_gdrive "$BACKUP_FILE_TEST" "$GDRIVE_FILE_NAME"
         fi
     fi
 

--- a/mysqlbackup.sh
+++ b/mysqlbackup.sh
@@ -225,7 +225,7 @@ upload_to_gdrive() {
     local file_name="${2:-$(basename "$file_path")}"
 
     # Controllo dimensione massima
-    if [ "$GDRIVE_MAX_SIZE_MB" -gt 0 ]; then
+    if [[ "$GDRIVE_MAX_SIZE_MB" =~ ^[0-9]+$ ]] && [ "$GDRIVE_MAX_SIZE_MB" -gt 0 ]; then
         local file_size_mb=$(( $(stat -c%s "$file_path" 2>/dev/null || stat -f%z "$file_path") / 1048576 ))
         if [ "$file_size_mb" -gt "$GDRIVE_MAX_SIZE_MB" ]; then
             echo "Warning: file $file_name ($file_size_mb MB) supera il limite di $GDRIVE_MAX_SIZE_MB MB, upload skippato"

--- a/mysqlbackup.sh
+++ b/mysqlbackup.sh
@@ -23,6 +23,7 @@ GDRIVE_REFRESH_TOKEN=""
 GDRIVE_FOLDER_ID=""
 GDRIVE_MAX_SIZE_MB=0
 GDRIVE_KEEP_FILES=0             # Numero di file da mantenere su Drive per ogni db (0 = nessun pruning)
+LOCK_TIMEOUT_MINUTES=120        # Timeout del lock file in minuti (default 2 ore), dopo il quale viene eliminato con warning
 
 EXCLUDE_TABLES_QUEUE=()
 EXCLUDE_TABLES_LOG_CACHE_SERVIZIO=()
@@ -44,6 +45,30 @@ if [[ -f $CONFIG_FILE ]]; then
 else
    echo "Could not load settings from $CONFIG_FILE (file does not exist), script use default settings."
 fi
+
+#
+# Lock file: impedisce esecuzioni concorrenti dello script
+# Se il lock esiste ed e' piu' vecchio di LOCK_TIMEOUT_MINUTES, viene eliminato con warning
+#
+LOCK_FILE="$CONFIG_DIR/mysqlbackup.lock"
+
+if [ -f "$LOCK_FILE" ]; then
+    # Calcola l'eta' del lock file in minuti
+    lock_age_seconds=$(( $(date +%s) - $(date -r "$LOCK_FILE" +%s 2>/dev/null || stat -c %Y "$LOCK_FILE") ))
+    lock_age_minutes=$(( lock_age_seconds / 60 ))
+
+    if [ $lock_age_minutes -ge $LOCK_TIMEOUT_MINUTES ]; then
+        echo "Warning: lock file presente da $lock_age_minutes minuti (timeout: $LOCK_TIMEOUT_MINUTES min), eliminazione forzata"
+        rm -f "$LOCK_FILE"
+    else
+        echo "Errore: un'altra istanza di mysqlbackup.sh e' gia' in esecuzione (lock file: $LOCK_FILE, eta': $lock_age_minutes min)"
+        exit 1
+    fi
+fi
+
+# Crea il lock file e registra la rimozione automatica all'uscita (anche in caso di errore)
+echo "$$" > "$LOCK_FILE"
+trap "rm -f '$LOCK_FILE'" EXIT
 
 # Verifico le opzioni inserite da linea di comando
 while [[ $# -gt 0 ]]; do

--- a/mysqlbackup.sh
+++ b/mysqlbackup.sh
@@ -221,6 +221,8 @@ if [[ ${#INCLUDE_DATABASES[@]} -gt 0 ]]; then
 fi
 
 
+# Skip del backup standard se si sta creando il database di test
+if [ "$CREATE_DATABASE_TEST" != true ]; then
 for database in $DBNAMES; do
     BACKUP_FILE="$DEFPATH/data/$database/$database-$DATA-dump.sql.gz"
 
@@ -255,6 +257,7 @@ for database in $DBNAMES; do
 
     echo "Backup db name $database finish at $(date +%Y-%m-%d.%H.%M.%S)"
 done
+fi
 
 #
 # Creazione database di test a partire dal database di produzione

--- a/mysqlbackup.sh
+++ b/mysqlbackup.sh
@@ -17,7 +17,9 @@ INCLUDE_DATABASES=()
 CREATE_DATABASE_TEST=false
 TEST_DATABASE_NAME=""
 SQL_SCRIPTS_DIR=""
-GDRIVE_SERVICE_ACCOUNT_JSON=""
+GDRIVE_CLIENT_ID=""
+GDRIVE_CLIENT_SECRET=""
+GDRIVE_REFRESH_TOKEN=""
 GDRIVE_FOLDER_ID=""
 GDRIVE_MAX_SIZE_MB=0
 
@@ -138,42 +140,21 @@ fi
 MYSQLCOMMAND+="$MYSQLCONFIG"
 
 #
-# Funzioni per upload su Google Drive via Service Account
+# Funzioni per upload su Google Drive via OAuth2 refresh token
 #
 
-# Ottiene un access token OAuth2 dal Service Account JSON usando JWT firmato con openssl
+# Ottiene un access token OAuth2 dal refresh token
 get_gdrive_token() {
-    # Estrae i campi dal JSON del service account
-    local client_email=$(grep '"client_email"' "$GDRIVE_SERVICE_ACCOUNT_JSON" | sed 's/.*: *"\(.*\)".*/\1/')
-    local token_uri=$(grep '"token_uri"' "$GDRIVE_SERVICE_ACCOUNT_JSON" | sed 's/.*: *"\(.*\)".*/\1/')
-
-    # Estrae la private key (campo multilinea con \n)
-    local private_key=$(sed -n '/private_key/,/-----END/p' "$GDRIVE_SERVICE_ACCOUNT_JSON" | sed 's/.*: *"//;s/",*$//' | sed 's/\\n/\n/g')
-
-    # JWT header e claim
-    local now=$(date +%s)
-    local exp=$((now + 3600))
-    local header='{"alg":"RS256","typ":"JWT"}'
-    local claim="{\"iss\":\"$client_email\",\"scope\":\"https://www.googleapis.com/auth/drive.file\",\"aud\":\"$token_uri\",\"iat\":$now,\"exp\":$exp}"
-
-    # Base64url encoding
-    local b64_header=$(echo -n "$header" | openssl base64 -e | tr -d '=\n' | tr '+/' '-_')
-    local b64_claim=$(echo -n "$claim" | openssl base64 -e | tr -d '=\n' | tr '+/' '-_')
-
-    # Firma RSA-SHA256 con la private key del service account
-    local signature=$(echo -n "$b64_header.$b64_claim" | openssl dgst -sha256 -sign <(echo "$private_key") | openssl base64 -e | tr -d '=\n' | tr '+/' '-_')
-
-    local jwt="$b64_header.$b64_claim.$signature"
-
-    # Scambia il JWT per un access token
-    local response=$(curl -s -X POST "$token_uri" \
-        -H "Content-Type: application/x-www-form-urlencoded" \
-        -d "grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=$jwt")
+    local response=$(curl -s -X POST "https://oauth2.googleapis.com/token" \
+        -d "client_id=$GDRIVE_CLIENT_ID" \
+        -d "client_secret=$GDRIVE_CLIENT_SECRET" \
+        -d "refresh_token=$GDRIVE_REFRESH_TOKEN" \
+        -d "grant_type=refresh_token")
 
     echo "$response" | grep -o '"access_token" *: *"[^"]*"' | sed 's/.*: *"\(.*\)"/\1/'
 }
 
-# Carica un file su Google Drive con controllo dimensione massima
+# Carica un file su Google Drive con controllo dimensione massima (resumable upload)
 # Parametri: $1 = path del file, $2 = nome del file su Drive (opzionale, default = basename)
 upload_to_gdrive() {
     local file_path="$1"
@@ -188,20 +169,33 @@ upload_to_gdrive() {
         fi
     fi
 
-    # Ottieni access token dal service account
     local token=$(get_gdrive_token)
     if [ -z "$token" ]; then
         echo "Errore: impossibile ottenere access token per Google Drive"
         return 1
     fi
 
-    # Upload via API Google Drive (multipart upload)
     echo "Uploading $file_name to Google Drive..."
-    local response=$(curl -s -X POST \
+
+    # Inizia upload resumable (robusto per file grandi)
+    local upload_url=$(curl -s -i -X POST \
         -H "Authorization: Bearer $token" \
-        -F "metadata={\"name\":\"$file_name\",\"parents\":[\"$GDRIVE_FOLDER_ID\"]};type=application/json;charset=UTF-8" \
-        -F "file=@$file_path;type=application/gzip" \
-        "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart")
+        -H "Content-Type: application/json" \
+        -d "{\"name\":\"$file_name\",\"parents\":[\"$GDRIVE_FOLDER_ID\"]}" \
+        "https://www.googleapis.com/upload/drive/v3/files?uploadType=resumable" | grep -i "^location:" | tr -d '\r' | sed 's/location: //i')
+
+    if [ -z "$upload_url" ]; then
+        echo "Errore: impossibile iniziare upload su Google Drive"
+        return 1
+    fi
+
+    # Upload del contenuto
+    local file_size=$(stat -c%s "$file_path" 2>/dev/null || stat -f%z "$file_path")
+    local response=$(curl -s -X PUT \
+        -H "Content-Length: $file_size" \
+        -H "Content-Type: application/gzip" \
+        --data-binary "@$file_path" \
+        "$upload_url")
 
     if echo "$response" | grep -q '"id"'; then
         echo "Upload completed: $file_name"
@@ -340,7 +334,7 @@ if [ "$CREATE_DATABASE_TEST" = true ]; then
 
     # Step 6: Upload su Google Drive (se configurato)
     # Il file su Drive si chiama nomedbprod_YYYY-MM-DD.sql.gz
-    if [ -n "$GDRIVE_SERVICE_ACCOUNT_JSON" ] && [ -n "$GDRIVE_FOLDER_ID" ]; then
+    if [ -n "$GDRIVE_REFRESH_TOKEN" ] && [ -n "$GDRIVE_FOLDER_ID" ]; then
         if [ -s "$BACKUP_FILE_TEST" ]; then
             GDRIVE_FILE_NAME="${database}_$(date +%Y-%m-%d).sql.gz"
             upload_to_gdrive "$BACKUP_FILE_TEST" "$GDRIVE_FILE_NAME"

--- a/mysqlbackup.sh
+++ b/mysqlbackup.sh
@@ -460,6 +460,11 @@ if [ "$CREATE_DATABASE_TEST" = true ]; then
     # Step 5: Export finale del database di test (compresso con gzip)
     BACKUP_FILE_TEST="$DEFPATH/data/$database/${database}_test_db-$DATA-dump.sql.gz"
     echo "Exporting test database $TEST_DATABASE_NAME..."
+    if ! command -v gzip > /dev/null 2>&1; then
+        echo "Errore: gzip non installato. --create-database-test richiede gzip per l'export finale compresso."
+        rm -f "$TEMP_SQL_FILE"
+        exit 1
+    fi
     $MYSQLDUMPBIN $MYSQLCONFIG $DBOPTION $TEST_DATABASE_NAME | gzip > "$BACKUP_FILE_TEST"
 
     if [ -s "$BACKUP_FILE_TEST" ]; then

--- a/mysqlbackup.sh
+++ b/mysqlbackup.sh
@@ -52,12 +52,36 @@ fi
 #
 LOCK_FILE="$CONFIG_DIR/mysqlbackup.lock"
 
+# Restituisce mtime epoch di un file in modo cross-platform (GNU stat -> BSD stat)
+get_file_mtime_epoch() {
+    local file="$1"
+    local mtime=""
+
+    mtime=$(stat -c %Y "$file" 2>/dev/null) || mtime=""
+    if [[ -z "$mtime" ]]; then
+        mtime=$(stat -f %m "$file" 2>/dev/null) || mtime=""
+    fi
+
+    if [[ "$mtime" =~ ^[0-9]+$ ]]; then
+        printf '%s\n' "$mtime"
+        return 0
+    fi
+
+    return 1
+}
+
 if [ -f "$LOCK_FILE" ]; then
     # Calcola l'eta' del lock file in minuti
-    lock_age_seconds=$(( $(date +%s) - $(date -r "$LOCK_FILE" +%s 2>/dev/null || stat -c %Y "$LOCK_FILE") ))
+    lock_mtime=$(get_file_mtime_epoch "$LOCK_FILE")
+    if [[ ! "$lock_mtime" =~ ^[0-9]+$ ]]; then
+        echo "Errore: impossibile determinare l'eta' del lock file in modo portabile (lock file: $LOCK_FILE)"
+        exit 1
+    fi
+
+    lock_age_seconds=$(( $(date +%s) - lock_mtime ))
     lock_age_minutes=$(( lock_age_seconds / 60 ))
 
-    if [ $lock_age_minutes -ge $LOCK_TIMEOUT_MINUTES ]; then
+    if [ "$lock_age_minutes" -ge "$LOCK_TIMEOUT_MINUTES" ]; then
         echo "Warning: lock file presente da $lock_age_minutes minuti (timeout: $LOCK_TIMEOUT_MINUTES min), eliminazione forzata"
         rm -f "$LOCK_FILE"
     else

--- a/mysqlbackup.sh
+++ b/mysqlbackup.sh
@@ -70,29 +70,43 @@ get_file_mtime_epoch() {
     return 1
 }
 
-if [ -f "$LOCK_FILE" ]; then
-    # Calcola l'eta' del lock file in minuti
-    lock_mtime=$(get_file_mtime_epoch "$LOCK_FILE")
-    if [[ ! "$lock_mtime" =~ ^[0-9]+$ ]]; then
-        echo "Errore: impossibile determinare l'eta' del lock file in modo portabile (lock file: $LOCK_FILE)"
-        exit 1
-    fi
+# Acquisizione atomica del lock file (noclobber impedisce race condition tra istanze concorrenti)
+acquire_lock() {
+    ( set -o noclobber; echo "$$" > "$LOCK_FILE" ) 2>/dev/null
+}
 
-    lock_age_seconds=$(( $(date +%s) - lock_mtime ))
-    lock_age_minutes=$(( lock_age_seconds / 60 ))
+if ! acquire_lock; then
+    if [ -f "$LOCK_FILE" ]; then
+        # Calcola l'eta' del lock file in minuti
+        lock_mtime=$(get_file_mtime_epoch "$LOCK_FILE")
+        if [[ ! "$lock_mtime" =~ ^[0-9]+$ ]]; then
+            echo "Errore: impossibile determinare l'eta' del lock file in modo portabile (lock file: $LOCK_FILE)"
+            exit 1
+        fi
 
-    if [ "$lock_age_minutes" -ge "$LOCK_TIMEOUT_MINUTES" ]; then
-        echo "Warning: lock file presente da $lock_age_minutes minuti (timeout: $LOCK_TIMEOUT_MINUTES min), eliminazione forzata"
-        rm -f "$LOCK_FILE"
+        lock_age_seconds=$(( $(date +%s) - lock_mtime ))
+        lock_age_minutes=$(( lock_age_seconds / 60 ))
+
+        if [ "$lock_age_minutes" -ge "$LOCK_TIMEOUT_MINUTES" ]; then
+            echo "Warning: lock file presente da $lock_age_minutes minuti (timeout: $LOCK_TIMEOUT_MINUTES min), eliminazione forzata"
+            rm -f "$LOCK_FILE"
+
+            if ! acquire_lock; then
+                echo "Errore: impossibile acquisire il lock dopo la rimozione del lock stale (lock file: $LOCK_FILE)"
+                exit 1
+            fi
+        else
+            echo "Errore: un'altra istanza di mysqlbackup.sh e' gia' in esecuzione (lock file: $LOCK_FILE, eta': $lock_age_minutes min)"
+            exit 1
+        fi
     else
-        echo "Errore: un'altra istanza di mysqlbackup.sh e' gia' in esecuzione (lock file: $LOCK_FILE, eta': $lock_age_minutes min)"
+        echo "Errore: impossibile acquisire il lock file $LOCK_FILE"
         exit 1
     fi
 fi
 
-# Crea il lock file e registra la rimozione automatica all'uscita (anche in caso di errore)
-echo "$$" > "$LOCK_FILE"
-trap "rm -f '$LOCK_FILE'" EXIT
+# Registra la rimozione automatica del lock all'uscita (anche in caso di errore)
+trap 'rm -f "$LOCK_FILE"' EXIT
 
 # Verifico le opzioni inserite da linea di comando
 while [[ $# -gt 0 ]]; do

--- a/mysqlbackup.sh
+++ b/mysqlbackup.sh
@@ -428,14 +428,14 @@ if [ "$CREATE_DATABASE_TEST" = true ]; then
     echo "Cleaning test database $TEST_DATABASE_NAME..."
     $MYSQLCOMMAND $TEST_DATABASE_NAME -e "SET FOREIGN_KEY_CHECKS=0"
 
-    TABLES=$($MYSQLCOMMAND $TEST_DATABASE_NAME -e "SHOW TABLES" -N)
-    for table in $TABLES; do
-        $MYSQLCOMMAND $TEST_DATABASE_NAME -e "DROP TABLE IF EXISTS \`$table\`"
-    done
-
     VIEWS=$($MYSQLCOMMAND $TEST_DATABASE_NAME -e "SHOW FULL TABLES WHERE Table_type='VIEW'" -N | awk '{print $1}')
     for view in $VIEWS; do
         $MYSQLCOMMAND $TEST_DATABASE_NAME -e "DROP VIEW IF EXISTS \`$view\`"
+    done
+
+    TABLES=$($MYSQLCOMMAND $TEST_DATABASE_NAME -e "SHOW FULL TABLES WHERE Table_type='BASE TABLE'" -N | awk '{print $1}')
+    for table in $TABLES; do
+        $MYSQLCOMMAND $TEST_DATABASE_NAME -e "DROP TABLE IF EXISTS \`$table\`"
     done
 
     $MYSQLCOMMAND $TEST_DATABASE_NAME -e "SET FOREIGN_KEY_CHECKS=1"

--- a/mysqlbackup.sh
+++ b/mysqlbackup.sh
@@ -451,7 +451,7 @@ if [ "$CREATE_DATABASE_TEST" = true ]; then
 
     # Step 4: Esecuzione degli script SQL di trasformazione (in ordine alfabetico/numerico)
     if [ -d "$SQL_SCRIPTS_DIR" ]; then
-        for script in $(ls "$SQL_SCRIPTS_DIR"/*.sql 2>/dev/null | sort); do
+        find "$SQL_SCRIPTS_DIR" -maxdepth 1 -type f -name "*.sql" -print0 | sort -z | while IFS= read -r -d '' script; do
             echo "Executing SQL script: $script"
             $MYSQLBIN $MYSQLCONFIG $TEST_DATABASE_NAME < "$script"
         done

--- a/mysqlbackup.sh
+++ b/mysqlbackup.sh
@@ -22,6 +22,7 @@ GDRIVE_CLIENT_SECRET=""
 GDRIVE_REFRESH_TOKEN=""
 GDRIVE_FOLDER_ID=""
 GDRIVE_MAX_SIZE_MB=0
+GDRIVE_KEEP_FILES=0             # Numero di file da mantenere su Drive per ogni db (0 = nessun pruning)
 
 EXCLUDE_TABLES_QUEUE=()
 EXCLUDE_TABLES_LOG_CACHE_SERVIZIO=()
@@ -189,20 +190,65 @@ upload_to_gdrive() {
         return 1
     fi
 
-    # Upload del contenuto
+    # Upload del contenuto e richiesta dei campi size per verifica
     local file_size=$(stat -c%s "$file_path" 2>/dev/null || stat -f%z "$file_path")
     local response=$(curl -s -X PUT \
         -H "Content-Length: $file_size" \
         -H "Content-Type: application/gzip" \
         --data-binary "@$file_path" \
-        "$upload_url")
+        "${upload_url}&fields=id,name,size")
 
-    if echo "$response" | grep -q '"id"'; then
-        echo "Upload completed: $file_name"
-    else
+    if ! echo "$response" | grep -q '"id"'; then
         echo "Errore upload Google Drive: $response"
         return 1
     fi
+
+    # Verifica che il file caricato non sia vuoto
+    local remote_size=$(echo "$response" | grep -o '"size" *: *"[^"]*"' | sed 's/.*: *"\(.*\)"/\1/')
+    if [ -n "$remote_size" ] && [ "$remote_size" = "0" ]; then
+        echo "Errore: il file caricato su Google Drive risulta vuoto (0 bytes)"
+        return 1
+    fi
+    echo "Upload completed: $file_name ($remote_size bytes)"
+}
+
+# Rimuove i file piu' vecchi su Google Drive, mantenendo solo gli ultimi N per ogni database
+# Il matching e' basato sul prefisso del nome db (es. "gescat_gianni_") escludendo la data
+# Parametri: $1 = prefisso del nome file (es. "gescat_gianni_"), $2 = numero di file da mantenere
+prune_gdrive_files() {
+    local file_prefix="$1"
+    local keep_count="$2"
+
+    local token=$(get_gdrive_token)
+    if [ -z "$token" ]; then
+        echo "Errore: impossibile ottenere access token per pruning Google Drive"
+        return 1
+    fi
+
+    # Cerca tutti i file nella cartella che matchano il prefisso, ordinati per data creazione decrescente
+    local response=$(curl -s -H "Authorization: Bearer $token" \
+        "https://www.googleapis.com/drive/v3/files?q='$GDRIVE_FOLDER_ID'+in+parents+and+name+contains+'${file_prefix}'+and+trashed=false&orderBy=createdTime+desc&fields=files(id,name,createdTime)&pageSize=100")
+
+    # Parsing dei risultati: estrae coppie id/name e salta i primi N (da mantenere)
+    local count=0
+    local i=0
+    local current_id=""
+
+    echo "$response" | grep -o '"id": *"[^"]*"\|"name": *"[^"]*"' | sed 's/.*: *"\(.*\)"/\1/' | while read -r value; do
+        if [ -z "$current_id" ]; then
+            # Primo valore della coppia: id
+            current_id="$value"
+        else
+            # Secondo valore della coppia: name
+            i=$((i + 1))
+            if [ $i -gt $keep_count ]; then
+                echo "Pruning: eliminazione $value da Google Drive..."
+                curl -s -X DELETE -H "Authorization: Bearer $token" \
+                    "https://www.googleapis.com/drive/v3/files/$current_id" > /dev/null
+            fi
+            current_id=""
+        fi
+    done
 }
 
 echo "retrieve databases..."
@@ -274,15 +320,38 @@ if [ "$CREATE_DATABASE_TEST" = true ]; then
         EXCLUDE_PARAMS+=" --ignore-table=$database.$table"
     done
 
-    # Step 1: Dump del database di produzione in un file .sql temporaneo (non compresso per l'import diretto)
-    TEMP_SQL_FILE="$DEFPATH/data/$database/${database}_export_db-$DATA-dump.sql"
+    #
+    # Step 1: Dump del database di produzione in un file temporaneo
+    # Se gzip e' disponibile comprime il dump per risparmiare spazio su disco
+    #
+    if command -v gzip &> /dev/null; then
+        TEMP_SQL_FILE="$DEFPATH/data/$database/${database}_export_db-$DATA-dump.sql.gz"
+        TEMP_USE_GZIP=true
+        echo "gzip disponibile, il dump intermedio sara' compresso"
+    else
+        TEMP_SQL_FILE="$DEFPATH/data/$database/${database}_export_db-$DATA-dump.sql"
+        TEMP_USE_GZIP=false
+        echo "gzip non disponibile, il dump intermedio sara' in chiaro"
+    fi
+
     echo "Dumping production database $database to temp file..."
-    {
-        for table in "${EXCLUDE_TABLES[@]}"; do
-            $MYSQLDUMPBIN $MYSQLCONFIG --no-data $database $table
-        done
-        $MYSQLDUMPBIN $MYSQLCONFIG $DBOPTION $EXCLUDE_PARAMS $database
-    } > "$TEMP_SQL_FILE"
+    if [ "$TEMP_USE_GZIP" = true ]; then
+        # Dump compresso: pipe diretta a gzip
+        {
+            for table in "${EXCLUDE_TABLES[@]}"; do
+                $MYSQLDUMPBIN $MYSQLCONFIG --no-data $database $table
+            done
+            $MYSQLDUMPBIN $MYSQLCONFIG $DBOPTION $EXCLUDE_PARAMS $database
+        } | gzip > "$TEMP_SQL_FILE"
+    else
+        # Dump non compresso
+        {
+            for table in "${EXCLUDE_TABLES[@]}"; do
+                $MYSQLDUMPBIN $MYSQLCONFIG --no-data $database $table
+            done
+            $MYSQLDUMPBIN $MYSQLCONFIG $DBOPTION $EXCLUDE_PARAMS $database
+        } > "$TEMP_SQL_FILE"
+    fi
 
     if [ ! -s "$TEMP_SQL_FILE" ]; then
         echo "Errore: dump del database di produzione fallito o vuoto"
@@ -309,8 +378,13 @@ if [ "$CREATE_DATABASE_TEST" = true ]; then
     $MYSQLCOMMAND $TEST_DATABASE_NAME -e "SET FOREIGN_KEY_CHECKS=1"
 
     # Step 3: Import del dump nel database di test
+    # Se il dump e' compresso, decomprime al volo con gunzip durante l'import
     echo "Importing dump into test database $TEST_DATABASE_NAME..."
-    $MYSQLBIN $MYSQLCONFIG $TEST_DATABASE_NAME < "$TEMP_SQL_FILE"
+    if [ "$TEMP_USE_GZIP" = true ]; then
+        gunzip -c "$TEMP_SQL_FILE" | $MYSQLBIN $MYSQLCONFIG $TEST_DATABASE_NAME
+    else
+        $MYSQLBIN $MYSQLCONFIG $TEST_DATABASE_NAME < "$TEMP_SQL_FILE"
+    fi
 
     # Step 4: Esecuzione degli script SQL di trasformazione (in ordine alfabetico/numerico)
     if [ -d "$SQL_SCRIPTS_DIR" ]; then
@@ -338,6 +412,12 @@ if [ "$CREATE_DATABASE_TEST" = true ]; then
         if [ -s "$BACKUP_FILE_TEST" ]; then
             GDRIVE_FILE_NAME="${database}_$(date +%Y-%m-%d).sql.gz"
             upload_to_gdrive "$BACKUP_FILE_TEST" "$GDRIVE_FILE_NAME"
+
+            # Step 7: Pruning dei file vecchi su Drive (se configurato)
+            # Mantiene solo gli ultimi N file per questo database, basandosi sul prefisso "nomedb_"
+            if [ "$GDRIVE_KEEP_FILES" -gt 0 ] 2>/dev/null; then
+                prune_gdrive_files "${database}_" "$GDRIVE_KEEP_FILES"
+            fi
         fi
     fi
 

--- a/mysqlbackup.sh
+++ b/mysqlbackup.sh
@@ -14,6 +14,9 @@ DATA=`/bin/date +"%a"`
 MYSQLBIN="/usr/bin/mysql"
 MYSQLDUMPBIN="/usr/bin/mysqldump"
 INCLUDE_DATABASES=()
+CREATE_DATABASE_TEST=false
+TEST_DATABASE_NAME=""
+SQL_SCRIPTS_DIR=""
 
 EXCLUDE_TABLES_QUEUE=()
 EXCLUDE_TABLES_LOG_CACHE_SERVIZIO=()
@@ -68,6 +71,10 @@ while [[ $# -gt 0 ]]; do
             IFS=',' read -ra EXCLUDE_TABLES <<< "$2"
             shift 2
             ;;
+        --create-database-test)
+            CREATE_DATABASE_TEST=true
+            shift
+            ;;
         --escludi_tutte)
             EXCLUDE_TABLES=("${EXCLUDE_TABLES_QUEUE[@]}" "${EXCLUDE_TABLES_LOG_CACHE_SERVIZIO[@]}" "${EXCLUDE_TABLES_STORICO[@]}" "${EXCLUDE_TABLES_STATISTICHE[@]}")
             shift
@@ -79,6 +86,33 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+
+#
+# Validazione --create-database-test
+# Richiede: esattamente 1 database via --databases, TEST_DATABASE_NAME configurato e diverso dal db di produzione
+#
+if [ "$CREATE_DATABASE_TEST" = true ]; then
+    if [ ${#INCLUDE_DATABASES[@]} -ne 1 ]; then
+        echo "Errore: --create-database-test richiede --databases con esattamente 1 database"
+        exit 1
+    fi
+    if [ -z "$TEST_DATABASE_NAME" ]; then
+        echo "Errore: TEST_DATABASE_NAME non configurato in $CONFIG_FILE"
+        exit 1
+    fi
+    # Evita di sovrascrivere il database di produzione
+    if [ "$TEST_DATABASE_NAME" = "${INCLUDE_DATABASES[0]}" ]; then
+        echo "Errore: TEST_DATABASE_NAME deve essere diverso dal database di produzione"
+        exit 1
+    fi
+    # Default per la directory degli script SQL di trasformazione
+    if [ -z "$SQL_SCRIPTS_DIR" ]; then
+        SQL_SCRIPTS_DIR="$CONFIG_DIR/sql_script_for_test_db"
+    fi
+    if [ ! -d "$SQL_SCRIPTS_DIR" ]; then
+        echo "Warning: directory $SQL_SCRIPTS_DIR non trovata, nessuno script SQL verra' eseguito"
+    fi
+fi
 
 MYSQLCOMMAND="$MYSQLBIN"
 MYSQLCONFIG=""
@@ -144,6 +178,91 @@ for database in $DBNAMES; do
 
     echo "Backup db name $database finish at $(date +%Y-%m-%d.%H.%M.%S)"
 done
+
+#
+# Creazione database di test a partire dal database di produzione
+# Flusso: dump prod -> import in test db -> esecuzione script SQL di trasformazione -> export test db
+#
+if [ "$CREATE_DATABASE_TEST" = true ]; then
+    database="${INCLUDE_DATABASES[0]}"
+    echo ""
+    echo "=== Create test database starts at $(date +%Y-%m-%d.%H.%M.%S) ==="
+    echo "Source database: $database"
+    echo "Test database: $TEST_DATABASE_NAME"
+
+    if [ ! -d "$DEFPATH/data/$database" ]; then
+        mkdir -p "$DEFPATH/data/$database"
+    fi
+
+    # Costruisce la lista di tabelle da escludere (stessa logica del backup standard)
+    EXCLUDE_PARAMS=""
+    for table in "${EXCLUDE_TABLES[@]}"; do
+        EXCLUDE_PARAMS+=" --ignore-table=$database.$table"
+    done
+
+    # Step 1: Dump del database di produzione in un file .sql temporaneo (non compresso per l'import diretto)
+    TEMP_SQL_FILE="$DEFPATH/data/$database/${database}_export_db-$DATA-dump.sql"
+    echo "Dumping production database $database to temp file..."
+    {
+        for table in "${EXCLUDE_TABLES[@]}"; do
+            $MYSQLDUMPBIN $MYSQLCONFIG --no-data $database $table
+        done
+        $MYSQLDUMPBIN $MYSQLCONFIG $DBOPTION $EXCLUDE_PARAMS $database
+    } > "$TEMP_SQL_FILE"
+
+    if [ ! -s "$TEMP_SQL_FILE" ]; then
+        echo "Errore: dump del database di produzione fallito o vuoto"
+        rm -f "$TEMP_SQL_FILE"
+        exit 1
+    fi
+    echo "Dump completed: $TEMP_SQL_FILE"
+
+    # Step 2: Drop di tutte le tabelle e viste nel database di test
+    # Disabilita FK per evitare errori di dipendenza tra tabelle
+    echo "Cleaning test database $TEST_DATABASE_NAME..."
+    $MYSQLCOMMAND $TEST_DATABASE_NAME -e "SET FOREIGN_KEY_CHECKS=0"
+
+    TABLES=$($MYSQLCOMMAND $TEST_DATABASE_NAME -e "SHOW TABLES" -N)
+    for table in $TABLES; do
+        $MYSQLCOMMAND $TEST_DATABASE_NAME -e "DROP TABLE IF EXISTS \`$table\`"
+    done
+
+    VIEWS=$($MYSQLCOMMAND $TEST_DATABASE_NAME -e "SHOW FULL TABLES WHERE Table_type='VIEW'" -N | awk '{print $1}')
+    for view in $VIEWS; do
+        $MYSQLCOMMAND $TEST_DATABASE_NAME -e "DROP VIEW IF EXISTS \`$view\`"
+    done
+
+    $MYSQLCOMMAND $TEST_DATABASE_NAME -e "SET FOREIGN_KEY_CHECKS=1"
+
+    # Step 3: Import del dump nel database di test
+    echo "Importing dump into test database $TEST_DATABASE_NAME..."
+    $MYSQLBIN $MYSQLCONFIG $TEST_DATABASE_NAME < "$TEMP_SQL_FILE"
+
+    # Step 4: Esecuzione degli script SQL di trasformazione (in ordine alfabetico/numerico)
+    if [ -d "$SQL_SCRIPTS_DIR" ]; then
+        for script in $(ls "$SQL_SCRIPTS_DIR"/*.sql 2>/dev/null | sort); do
+            echo "Executing SQL script: $script"
+            $MYSQLBIN $MYSQLCONFIG $TEST_DATABASE_NAME < "$script"
+        done
+    fi
+
+    # Step 5: Export finale del database di test (compresso con gzip)
+    BACKUP_FILE_TEST="$DEFPATH/data/$database/${database}_test_db-$DATA-dump.sql.gz"
+    echo "Exporting test database $TEST_DATABASE_NAME..."
+    $MYSQLDUMPBIN $MYSQLCONFIG $DBOPTION $TEST_DATABASE_NAME | gzip > "$BACKUP_FILE_TEST"
+
+    if [ -s "$BACKUP_FILE_TEST" ]; then
+        echo "Test database export completed: $BACKUP_FILE_TEST"
+    else
+        echo "Errore: export del database di test fallito o vuoto"
+        rm -f "$BACKUP_FILE_TEST"
+    fi
+
+    # Cleanup: rimuove il file .sql temporaneo
+    rm -f "$TEMP_SQL_FILE"
+
+    echo "=== Create test database finish at $(date +%Y-%m-%d.%H.%M.%S) ==="
+fi
 
 _now=$(date +%Y-%m-%d.%H.%M.%S)
 echo "Finish at $_now"

--- a/mysqlbackup.sh
+++ b/mysqlbackup.sh
@@ -210,10 +210,10 @@ MYSQLCOMMAND+="$MYSQLCONFIG"
 # Ottiene un access token OAuth2 dal refresh token
 get_gdrive_token() {
     local response=$(curl -s -X POST "https://oauth2.googleapis.com/token" \
-        -d "client_id=$GDRIVE_CLIENT_ID" \
-        -d "client_secret=$GDRIVE_CLIENT_SECRET" \
-        -d "refresh_token=$GDRIVE_REFRESH_TOKEN" \
-        -d "grant_type=refresh_token")
+        --data-urlencode "client_id=$GDRIVE_CLIENT_ID" \
+        --data-urlencode "client_secret=$GDRIVE_CLIENT_SECRET" \
+        --data-urlencode "refresh_token=$GDRIVE_REFRESH_TOKEN" \
+        --data-urlencode "grant_type=refresh_token")
 
     echo "$response" | grep -o '"access_token" *: *"[^"]*"' | sed 's/.*: *"\(.*\)"/\1/'
 }


### PR DESCRIPTION
## Summary
- Nuova flag `--create-database-test` per creare un database di test a partire da quello di produzione
- Flusso: dump prod DB → import in test DB → esecuzione script SQL di trasformazione → export test DB compresso
- Upload automatico su Google Drive via OAuth2 refresh token (resumable upload)
- Skip del backup standard quando si usa `--create-database-test`
- Nuove variabili nel config: `TEST_DATABASE_NAME`, `SQL_SCRIPTS_DIR`, credenziali OAuth2 Google Drive

## Test plan
- [x] Validazione CLI: errore se manca `--databases`, se ne passa piu' di uno, se `TEST_DATABASE_NAME` non configurato o uguale al DB prod
- [x] Flusso completo testato su `gescat_gianni` (5.3 GB) e `gescat_pissei` (3.7 GB)
- [x] Upload su Google Drive verificato con file da 166 MB
- [x] Testare con script SQL nella cartella `sql_script_for_test_db/`
- [x] Testare limite `GDRIVE_MAX_SIZE_MB`

🤖 Generated with [Claude Code](https://claude.com/claude-code)